### PR TITLE
Fixes #739 - HTML logs included in pickles

### DIFF
--- a/master/buildbot/status/logfile.py
+++ b/master/buildbot/status/logfile.py
@@ -644,29 +644,40 @@ class HTMLLogFile:
         self.step = parent
         self.name = name
         self.filename = logfilename
-        self.html = html
+        with open(self.getFilename(), 'w') as f:
+            f.write(html)
 
     def getName(self):
         return self.name # set in BuildStepStatus.addLog
+
     def getStep(self):
         return self.step
 
+    def getFilename(self):
+        return os.path.join(self.step.build.builder.basedir, self.filename)
+
     def isFinished(self):
         return True
+
     def waitUntilFinished(self):
         return defer.succeed(self)
 
     def hasContents(self):
         return True
+
     def getText(self):
-        return self.html # looks kinda like text
+        with open(self.getFilename()) as f:
+            return f.read()
+
     def getTextWithHeaders(self):
-        return self.html
+        return self.getText()
+
     def getChunks(self):
-        return [(STDERR, self.html)]
+        return [(STDERR, self.getText())]
 
     def subscribe(self, receiver, catchup):
         pass
+
     def unsubscribe(self, receiver):
         pass
 

--- a/master/buildbot/status/web/logs.py
+++ b/master/buildbot/status/web/logs.py
@@ -156,7 +156,7 @@ class HTMLLog(Resource):
 
     def render(self, request):
         request.setHeader("content-type", "text/html")
-        return self.original.html
+        return self.original.getText()
 
 components.registerAdapter(HTMLLog, logfile.HTMLLogFile, IHTMLLog)
 


### PR DESCRIPTION
No tests needed updating and we didn't think it worth the effort to write new tests for this since will go away in 0.9.
